### PR TITLE
Enhance today briefing layout and styling

### DIFF
--- a/web/src/components/CategoryColumn.tsx
+++ b/web/src/components/CategoryColumn.tsx
@@ -1,3 +1,5 @@
+import { useMemo, useState } from 'react'
+
 type Item = {
   url: string
   source_name: string
@@ -7,22 +9,66 @@ type Item = {
 }
 
 export default function CategoryColumn({ title, items }: { title: string, items: Item[] }) {
+  const [showEnglish, setShowEnglish] = useState(false)
+  const hasTranslations = useMemo(() => items.some(it => !!it.title_en), [items])
+
+  function formatTime(value?: string) {
+    if (!value) return null
+    try {
+      return new Date(value).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })
+    } catch (err) {
+      return null
+    }
+  }
+
   return (
-    <section aria-label={title} className="flex-1 min-w-[260px]">
-      <div className="sticky top-12 bg-gray-50 border-b px-3 py-2 font-medium">{title}</div>
-      <ul className="divide-y">
-        {items.map((it, idx) => (
-          <li key={it.url + idx} className="px-3 py-2">
-            <a href={it.url} target="_blank" rel="noreferrer" className="block group">
-              <div className="text-[13px] text-gray-500">
-                <span className="inline-block border rounded px-1 mr-2">{it.source_name}</span>
-                <time>{it.published_at ? new Date(it.published_at).toLocaleTimeString([], {hour: '2-digit', minute: '2-digit'}) : ''}</time>
-              </div>
-              <div className="font-medium leading-snug group-hover:underline">{it.title_zh}</div>
-              {it.title_en && <div className="text-sm text-gray-700">{it.title_en}</div>}
-            </a>
-          </li>
-        ))}
+    <section
+      aria-label={title}
+      className="flex h-full flex-col overflow-hidden rounded-3xl border border-slate-200 bg-white shadow-sm"
+    >
+      <div className="flex items-start justify-between gap-4 border-b border-slate-200 bg-slate-50 px-5 py-4">
+        <h3 className="text-base font-semibold text-slate-900">{title}</h3>
+        {hasTranslations && (
+          <button
+            type="button"
+            onClick={() => setShowEnglish(v => !v)}
+            className="inline-flex items-center rounded-full border border-slate-300 bg-white px-3 py-1 text-xs font-medium text-slate-600 transition hover:border-slate-400 hover:text-slate-800"
+            aria-pressed={showEnglish}
+          >
+            {showEnglish ? 'Hide EN' : 'Show EN'}
+          </button>
+        )}
+      </div>
+      <ul className="flex flex-1 flex-col gap-4 px-5 py-5">
+        {items.length === 0 && (
+          <li className="text-sm text-slate-500">No coverage captured yet.</li>
+        )}
+        {items.map((it, idx) => {
+          const time = formatTime(it.published_at)
+          return (
+            <li key={it.url + idx} className="group">
+              <a
+                href={it.url}
+                target="_blank"
+                rel="noreferrer"
+                className="block rounded-2xl border border-transparent px-4 py-3 transition hover:border-slate-200 hover:bg-slate-50"
+              >
+                <div className="flex flex-wrap items-center gap-2 text-xs text-slate-500">
+                  <span className="inline-flex items-center rounded-full bg-slate-100 px-2 py-0.5 font-medium text-slate-700">
+                    {it.source_name}
+                  </span>
+                  {time && <time className="font-medium text-slate-600">{time}</time>}
+                </div>
+                <p className="mt-2 text-sm font-medium leading-snug text-slate-900 group-hover:text-slate-950">
+                  {it.title_zh}
+                </p>
+                {showEnglish && it.title_en && (
+                  <p className="mt-1 text-sm leading-relaxed text-slate-600">{it.title_en}</p>
+                )}
+              </a>
+            </li>
+          )
+        })}
       </ul>
     </section>
   )

--- a/web/src/components/SummaryCard.tsx
+++ b/web/src/components/SummaryCard.tsx
@@ -6,37 +6,45 @@ type Summary = {
   notable_quotes?: string[]
 }
 
+function SummaryList({ title, items }: { title: string, items: string[] }) {
+  if (!items || items.length === 0) return null
+  return (
+    <section className="space-y-2">
+      <h4 className="text-xs font-semibold uppercase tracking-wide text-slate-500">{title}</h4>
+      <ul className="grid grid-cols-1 gap-2 text-sm text-slate-700 sm:grid-cols-2">
+        {items.map((t, i) => (
+          <li key={i} className="flex items-start gap-2 rounded-xl bg-white/60 px-3 py-2 shadow-sm ring-1 ring-slate-100">
+            <span className="mt-0.5 text-slate-400" aria-hidden>•</span>
+            <span className="leading-5">{t}</span>
+          </li>
+        ))}
+      </ul>
+    </section>
+  )
+}
+
 export default function SummaryCard({ title, data }: { title: string, data?: Summary }) {
   if (!data) return null
-  return (
-    <article className="border rounded p-4 bg-white shadow-sm">
-      <h3 className="font-semibold mb-2">{title}</h3>
-      <p className="text-sm leading-6 whitespace-pre-wrap">{data.executive_summary}</p>
+  const { executive_summary, key_themes, cross_outlet_contrasts, watchlist, notable_quotes } = data
 
-      {data.key_themes && data.key_themes.length > 0 && (
-        <section className="mt-3">
-          <h4 className="text-sm font-medium">Key themes</h4>
-          <ul className="list-disc list-inside text-sm">
-            {data.key_themes.map((t, i) => <li key={i}>{t}</li>)}
-          </ul>
-        </section>
-      )}
-      {data.cross_outlet_contrasts && data.cross_outlet_contrasts.length > 0 && (
-        <section className="mt-3">
-          <h4 className="text-sm font-medium">Contrasts</h4>
-          <ul className="list-disc list-inside text-sm">
-            {data.cross_outlet_contrasts.map((t, i) => <li key={i}>{t}</li>)}
-          </ul>
-        </section>
-      )}
-      {data.watchlist && data.watchlist.length > 0 && (
-        <section className="mt-3">
-          <h4 className="text-sm font-medium">Watchlist</h4>
-          <ul className="list-disc list-inside text-sm">
-            {data.watchlist.map((t, i) => <li key={i}>{t}</li>)}
-          </ul>
-        </section>
-      )}
+  return (
+    <article className="flex h-full flex-col gap-5 overflow-hidden rounded-3xl border border-slate-200 bg-gradient-to-br from-slate-50 via-white to-white p-6 shadow-md">
+      <header className="flex items-start gap-4">
+        <span className="inline-flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-full bg-slate-900/90 text-lg text-white shadow">
+          📰
+        </span>
+        <div>
+          <h3 className="text-lg font-semibold text-slate-900">{title}</h3>
+          <p className="mt-1 text-sm leading-6 text-slate-600 whitespace-pre-wrap">{executive_summary}</p>
+        </div>
+      </header>
+
+      <div className="space-y-5 text-sm leading-6 text-slate-700">
+        <SummaryList title="Key themes" items={key_themes || []} />
+        <SummaryList title="Contrasts" items={cross_outlet_contrasts || []} />
+        <SummaryList title="Watchlist" items={watchlist || []} />
+        <SummaryList title="Notable quotes" items={notable_quotes || []} />
+      </div>
     </article>
   )
 }

--- a/web/src/pages/Today.tsx
+++ b/web/src/pages/Today.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import Header from '../components/Header'
 import CategoryColumn from '../components/CategoryColumn'
 import SummaryCard from '../components/SummaryCard'
@@ -46,25 +46,68 @@ export default function Today() {
     else { alert('Failed: ' + (await r.text())) }
   }
 
-  const order = Object.keys(CAT_LABELS)
+  const order = useMemo(() => Object.keys(CAT_LABELS), [])
+  const briefingMeta = useMemo(() => {
+    if (!data) return null
+    const totalArticles = order.reduce((sum, key) => sum + (data.categories[key]?.length || 0), 0)
+    return { totalArticles, lastRun: data.meta?.run_started_at }
+  }, [data, order])
 
   return (
-    <div className="min-h-screen">
+    <div className="min-h-screen bg-slate-50">
       <Header onRescan={rescan} lastRun={data?.meta.run_started_at} />
-      <main className="max-w-7xl mx-auto p-4">
+      <main className="max-w-7xl mx-auto px-4 pb-10">
         {error && <div className="p-3 border rounded bg-yellow-50 text-sm">{error}</div>}
-        {!data ? <div>Loading…</div> : (
+        {!data ? <div className="mt-10 text-center text-sm text-slate-600">Loading…</div> : (
           <>
-            <section className="grid md:grid-cols-2 lg:grid-cols-4 gap-4">
-              {order.map(c => (
-                <CategoryColumn key={c} title={CAT_LABELS[c]} items={data.categories[c] || []} />
-              ))}
+            {briefingMeta && (
+              <section
+                aria-label="Briefing overview"
+                className="mt-6 rounded-3xl border border-slate-200 bg-white/70 px-6 py-5 shadow-sm backdrop-blur"
+              >
+                <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+                  <div>
+                    <h1 className="text-2xl font-semibold text-slate-900">Today&rsquo;s Briefing</h1>
+                    <p className="mt-1 text-sm text-slate-600">
+                      A snapshot of the latest China coverage, refreshed whenever a new scan completes.
+                    </p>
+                  </div>
+                  <dl className="grid grid-cols-1 gap-3 text-sm sm:grid-cols-2">
+                    <div className="rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 text-center">
+                      <dt className="text-xs uppercase tracking-wide text-slate-500">Total articles</dt>
+                      <dd className="mt-1 text-xl font-semibold text-slate-900">{briefingMeta.totalArticles}</dd>
+                    </div>
+                    <div className="rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 text-center">
+                      <dt className="text-xs uppercase tracking-wide text-slate-500">Last run</dt>
+                      <dd className="mt-1 text-sm font-medium text-slate-900">
+                        {briefingMeta.lastRun ? new Date(briefingMeta.lastRun).toLocaleString() : '—'}
+                      </dd>
+                    </div>
+                  </dl>
+                </div>
+              </section>
+            )}
+
+            <section className="mt-8 space-y-6" aria-label="Category coverage">
+              <div className="flex items-center justify-between">
+                <h2 className="text-lg font-semibold text-slate-900">Category coverage</h2>
+              </div>
+              <div className="grid gap-6 md:grid-cols-2 xl:grid-cols-3">
+                {order.map(c => (
+                  <CategoryColumn key={c} title={CAT_LABELS[c]} items={data.categories[c] || []} />
+                ))}
+              </div>
             </section>
-            <h2 className="mt-8 mb-3 text-lg font-semibold">Daily Wrap-up</h2>
-            <section className="grid md:grid-cols-2 gap-4">
-              {order.map(c => (
-                <SummaryCard key={c} title={CAT_LABELS[c]} data={data.summaries[c]} />
-              ))}
+
+            <section className="mt-10 space-y-4" aria-label="Daily wrap-up summaries">
+              <div className="flex items-center justify-between">
+                <h2 className="text-lg font-semibold text-slate-900">Daily wrap-up</h2>
+              </div>
+              <div className="grid gap-6 md:grid-cols-2">
+                {order.map(c => (
+                  <SummaryCard key={c} title={CAT_LABELS[c]} data={data.summaries[c]} />
+                ))}
+              </div>
             </section>
           </>
         )}


### PR DESCRIPTION
## Summary
- add a briefing overview banner with run metadata and responsive grids on the Today page
- restyle category coverage cards with translation toggles, source badges, and improved spacing
- redesign the daily summary cards with highlighted typography and accessible multi-column lists

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dd37a328e08331a983f8ac18beacfa