### PR TITLE
Load feed registry from JSON configuration

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -10,6 +10,10 @@ Copy `.env.example` to `.env` and set your values. The default DB is SQLite at `
 ## Legal & Robots
 Prefer official RSS feeds and respect each site’s Terms of Service and robots.txt. Throttle requests and cache feeds.
 
+## Feeds registry
+- Edit `src/feeds/sources.json` to add, update, or remove outlets. Each source entry must include an `id`, human-readable `name`, `homepage_url`, and at least one feed with a `url`. Optional fields such as `region`, `tier`, and `section_hint` help downstream categorisation but are not required.
+- No code changes are necessary after updating the JSON. The registry loader validates the file on startup and populates the database automatically during scans.
+
 ## API
 - `POST /api/scan` (auth: Bearer `ADMIN_TOKEN`) – run full scan now.
 - `GET /api/today` – latest scan.

--- a/server/src/feeds/registry.js
+++ b/server/src/feeds/registry.js
@@ -1,65 +1,99 @@
-// Registry of news sources and feed endpoints (prefer official RSS)
-export const SOURCE_REGISTRY = [
-  {
-    id: "peoples_daily",
-    name: "人民日报 / People's Daily",
-    region: "Mainland",
-    tier: "central",
-    homepage_url: "https://www.people.com.cn",
-    feeds: [
-      { name: "politics", url: "http://www.people.com.cn/rss/politics.xml", section_hint: "domestic_politics" },
-      { name: "society",  url: "http://www.people.com.cn/rss/society.xml",  section_hint: "society" }
-    ]
-  },
-  {
-    id: "beijing_daily",
-    name: "北京日报 / Beijing Daily",
-    region: "Beijing",
-    tier: "municipal",
-    homepage_url: "https://www.bjd.com.cn/",
-    feeds: [
-      { name: "main", url: "https://rss2.bjd.com.cn/", section_hint: "domestic_politics" }
-    ]
-  },
-  {
-    id: "economic_daily",
-    name: "经济日报 / Economic Daily",
-    region: "Mainland",
-    tier: "central",
-    homepage_url: "https://www.ce.cn/",
-    feeds: [
-      { name: "rss", url: "https://rss.jingjiribao.cn/", section_hint: "business" }
-    ]
-  },
-  {
-    id: "ming_pao",
-    name: "明报 / Ming Pao (HK)",
-    region: "Hong Kong",
-    tier: "regional",
-    homepage_url: "https://news.mingpao.com/",
-    feeds: [
-      { name: "all", url: "https://news.mingpao.com/php/rss.php", section_hint: "mixed" }
-    ]
-  },
-  {
-    id: "hket",
-    name: "香港经济日报 / HKET",
-    region: "Hong Kong",
-    tier: "regional",
-    homepage_url: "https://www.hket.com/",
-    feeds: [
-      { name: "rss_index", url: "https://www.hket.com/rss", section_hint: "business" }
-    ]
-  },
-  {
-    id: "ltn",
-    name: "自由时报 / Liberty Times (TW)",
-    region: "Taiwan",
-    tier: "regional",
-    homepage_url: "https://www.ltn.com.tw/",
-    feeds: [
-      { name: "rss_index", url: "https://service.ltn.com.tw/RSS", section_hint: "mixed" }
-    ]
+import fs from "fs";
+import path from "path";
+import { fileURLToPath } from "url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const SOURCES_PATH = path.join(__dirname, "sources.json");
+
+function expectString(value, errorMessage) {
+  if (typeof value !== "string" || value.trim() === "") {
+    throw new Error(errorMessage);
   }
-  // Add more sources here as needed; for outlets without official RSS, use RSSHub or a site-specific adapter.
-];
+  return value.trim();
+}
+
+function normalizeFeed(feed, sourceId, feedIndex) {
+  if (typeof feed !== "object" || feed === null) {
+    throw new Error(`Feed entry ${feedIndex} for source "${sourceId}" must be an object.`);
+  }
+
+  const url = expectString(feed.url, `Feed entry ${feedIndex} for source "${sourceId}" is missing a url.`);
+  const normalized = {
+    ...feed,
+    url,
+  };
+
+  if ("name" in normalized) {
+    normalized.name = expectString(normalized.name, `Feed entry ${feedIndex} for source "${sourceId}" has an invalid name.`);
+  }
+
+  if (!("section_hint" in normalized) || normalized.section_hint === undefined || normalized.section_hint === null) {
+    normalized.section_hint = "mixed";
+  } else {
+    normalized.section_hint = expectString(normalized.section_hint, `Feed entry ${feedIndex} for source "${sourceId}" has an invalid section_hint.`);
+  }
+
+  return normalized;
+}
+
+function normalizeSource(source, index) {
+  if (typeof source !== "object" || source === null) {
+    throw new Error(`Source entry at index ${index} must be an object.`);
+  }
+
+  const id = expectString(source.id, `Source entry at index ${index} is missing an id.`);
+  const name = expectString(source.name, `Source "${id}" is missing a name.`);
+  const homepageUrl = expectString(source.homepage_url, `Source "${id}" is missing a homepage_url.`);
+  const feedsRaw = source.feeds ?? [];
+
+  if (!Array.isArray(feedsRaw) || feedsRaw.length === 0) {
+    throw new Error(`Source "${id}" must declare at least one feed entry.`);
+  }
+
+  const feeds = feedsRaw.map((feed, feedIndex) => normalizeFeed(feed, id, feedIndex));
+
+  return {
+    ...source,
+    id,
+    name,
+    homepage_url: homepageUrl,
+    feeds,
+    enabled: source.enabled ?? 1,
+  };
+}
+
+function parseSources(json) {
+  if (!Array.isArray(json)) {
+    throw new Error("Sources registry JSON must be an array of sources.");
+  }
+
+  return json.map((source, index) => normalizeSource(source, index));
+}
+
+export function loadSourceRegistry() {
+  const contents = fs.readFileSync(SOURCES_PATH, "utf8");
+  let parsed;
+  try {
+    parsed = JSON.parse(contents);
+  } catch (error) {
+    throw new Error(`Unable to parse sources registry JSON at ${SOURCES_PATH}: ${error.message}`);
+  }
+  return parseSources(parsed);
+}
+
+export const SOURCE_REGISTRY = loadSourceRegistry();
+
+export function getAllSources() {
+  return SOURCE_REGISTRY;
+}
+
+export function getEnabledSources() {
+  return SOURCE_REGISTRY.filter((source) => source.enabled !== 0);
+}
+
+export function getSourceById(id) {
+  return SOURCE_REGISTRY.find((source) => source.id === id) ?? null;
+}
+
+export { SOURCES_PATH };

--- a/server/src/feeds/sources.json
+++ b/server/src/feeds/sources.json
@@ -1,0 +1,63 @@
+[
+  {
+    "id": "peoples_daily",
+    "name": "人民日报 / People's Daily",
+    "region": "Mainland",
+    "tier": "central",
+    "homepage_url": "https://www.people.com.cn",
+    "feeds": [
+      { "name": "politics", "url": "http://www.people.com.cn/rss/politics.xml", "section_hint": "domestic_politics" },
+      { "name": "society", "url": "http://www.people.com.cn/rss/society.xml", "section_hint": "society" }
+    ]
+  },
+  {
+    "id": "beijing_daily",
+    "name": "北京日报 / Beijing Daily",
+    "region": "Beijing",
+    "tier": "municipal",
+    "homepage_url": "https://www.bjd.com.cn/",
+    "feeds": [
+      { "name": "main", "url": "https://rss2.bjd.com.cn/", "section_hint": "domestic_politics" }
+    ]
+  },
+  {
+    "id": "economic_daily",
+    "name": "经济日报 / Economic Daily",
+    "region": "Mainland",
+    "tier": "central",
+    "homepage_url": "https://www.ce.cn/",
+    "feeds": [
+      { "name": "rss", "url": "https://rss.jingjiribao.cn/", "section_hint": "business" }
+    ]
+  },
+  {
+    "id": "ming_pao",
+    "name": "明报 / Ming Pao (HK)",
+    "region": "Hong Kong",
+    "tier": "regional",
+    "homepage_url": "https://news.mingpao.com/",
+    "feeds": [
+      { "name": "all", "url": "https://news.mingpao.com/php/rss.php", "section_hint": "mixed" }
+    ]
+  },
+  {
+    "id": "hket",
+    "name": "香港经济日报 / HKET",
+    "region": "Hong Kong",
+    "tier": "regional",
+    "homepage_url": "https://www.hket.com/",
+    "feeds": [
+      { "name": "rss_index", "url": "https://www.hket.com/rss", "section_hint": "business" }
+    ]
+  },
+  {
+    "id": "ltn",
+    "name": "自由时报 / Liberty Times (TW)",
+    "region": "Taiwan",
+    "tier": "regional",
+    "homepage_url": "https://www.ltn.com.tw/",
+    "feeds": [
+      { "name": "rss_index", "url": "https://service.ltn.com.tw/RSS", "section_hint": "mixed" }
+    ]
+  }
+]


### PR DESCRIPTION
## Summary
- move the news source definitions into `server/src/feeds/sources.json`
- add a registry loader that reads and validates the JSON and exposes helper accessors
- update the full scan workflow to use the new helpers while seeding the database, and document how to edit the registry

## Testing
- npm --prefix server run build

------
https://chatgpt.com/codex/tasks/task_e_68ddbd73fa188331ab2447304ef56cdc