### PR TITLE
Add scan status tracking and UI status bar

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "beijing-brief-server",
+  "name": "china-compass-server",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "beijing-brief-server",
+      "name": "china-compass-server",
       "version": "0.1.0",
       "dependencies": {
         "better-sqlite3": "^9.6.0",

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -6,7 +6,7 @@ import { fileURLToPath } from "url";
 import { config } from "./util/config.js";
 import { db } from "./util/db.js";
 import { runFullScan } from "./scan/runFullScan.js";
-import { getLatestScan, getScanById, listScans } from "./scan/queries.js";
+import { getLatestScan, getLatestScanStatus, getScanById, listScans } from "./scan/queries.js";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const app = express();
@@ -33,6 +33,12 @@ app.get("/api/today", async (_req, res) => {
   const scan = getLatestScan();
   if (!scan) return res.status(404).json({ error: "No scans yet" });
   res.json(scan);
+});
+
+app.get("/api/status", async (_req, res) => {
+  const status = getLatestScanStatus();
+  if (!status) return res.status(404).json({ error: "No scans yet" });
+  res.json(status);
 });
 
 app.get("/api/scans", async (req, res) => {

--- a/server/src/scan/queries.js
+++ b/server/src/scan/queries.js
@@ -1,4 +1,3 @@
-import dayjs from "dayjs";
 import { db } from "../util/db.js";
 
 export function getLatestScan() {
@@ -45,4 +44,71 @@ function groupByCategory(items) {
     map[cat].push(it);
   }
   return map;
+}
+
+export function getLatestScanStatus() {
+  const scan = db.prepare("SELECT * FROM scans ORDER BY run_started_at DESC LIMIT 1").get();
+  if (!scan) return null;
+
+  const rows = db.prepare(`
+    SELECT sss.*, src.name AS source_name, src.region AS source_region, src.tier AS source_tier
+    FROM scan_source_statuses sss
+    LEFT JOIN sources src ON src.id = sss.source_id
+    WHERE sss.scan_id = ?
+  `).all(scan.id);
+
+  const sources = [];
+  let openai = null;
+  for (const row of rows) {
+    if (row.source_id === "__openai__") {
+      openai = {
+        source_id: row.source_id,
+        classification_status: row.classification_status,
+        translation_status: row.translation_status,
+        summarization_status: row.summarization_status,
+        openai_connected: row.openai_connected,
+        openai_error: row.openai_error,
+        last_updated_at: row.last_updated_at,
+      };
+    } else {
+      sources.push({
+        source_id: row.source_id,
+        source_name: row.source_name || row.source_id,
+        source_region: row.source_region,
+        source_tier: row.source_tier,
+        fetch_status: row.fetch_status,
+        fetch_started_at: row.fetch_started_at,
+        fetch_completed_at: row.fetch_completed_at,
+        article_count: row.article_count,
+        error_message: row.error_message,
+        last_updated_at: row.last_updated_at,
+      });
+    }
+  }
+
+  sources.sort((a, b) => {
+    const priority = (status) => {
+      if (status === 'error') return 0;
+      if (status === 'running') return 1;
+      if (status === 'pending') return 2;
+      return 3;
+    };
+    const diff = priority(a.fetch_status) - priority(b.fetch_status);
+    if (diff !== 0) return diff;
+    return a.source_name.localeCompare(b.source_name);
+  });
+
+  return {
+    scan: {
+      id: scan.id,
+      run_started_at: scan.run_started_at,
+      run_completed_at: scan.run_completed_at,
+      schedule_kind: scan.schedule_kind,
+      timezone: scan.timezone,
+      total_articles: scan.total_articles,
+      status: scan.status || (scan.run_completed_at ? 'complete' : 'running')
+    },
+    sources,
+    openai,
+  };
 }

--- a/server/src/scan/runFullScan.js
+++ b/server/src/scan/runFullScan.js
@@ -5,18 +5,77 @@ import { db } from "../util/db.js";
 import { config } from "../util/config.js";
 import { getAllSources, getEnabledSources } from "../feeds/registry.js";
 import { fetchFeed } from "../feeds/fetchFeeds.js";
-import { articleIdFrom, normalizeTitle, groupBy, CATEGORY_ORDER } from "./helpers.js";
+import { articleIdFrom, normalizeTitle, groupBy } from "./helpers.js";
 import { classifyItems, translateItems, summarizeCategory, hashStable } from "../ai/openai.js";
 
 dayjs.extend(utc);
 dayjs.extend(timezone);
 
+const OPENAI_SOURCE_ID = "__openai__";
+const MAX_ERROR_LENGTH = 500;
+
+function truncateError(err) {
+  if (!err) return null;
+  const message = typeof err === "string" ? err : (err.message || String(err));
+  return message.slice(0, MAX_ERROR_LENGTH);
+}
+
 export async function runFullScan({ manual=false } = {}) {
   const startedAt = dayjs().tz(config.TZ).toISOString();
   const scanId = hashStable(startedAt + "|" + (manual ? "manual" : "scheduled"));
+  const now = () => dayjs().tz(config.TZ).toISOString();
 
-  db.prepare("INSERT INTO scans (id, run_started_at, schedule_kind, timezone, total_articles) VALUES (?, ?, ?, ?, 0)")
+  db.prepare("INSERT INTO scans (id, run_started_at, schedule_kind, timezone, total_articles, status) VALUES (?, ?, ?, ?, 0, 'running')")
     .run(scanId, startedAt, manual ? "manual" : "scheduled", config.TZ);
+
+  const ensureStatusRow = db.prepare(`
+    INSERT OR IGNORE INTO scan_source_statuses (scan_id, source_id, fetch_status, article_count, last_updated_at)
+    VALUES (?, ?, 'pending', 0, ?)
+  `);
+
+  const startFetch = db.prepare(`
+    UPDATE scan_source_statuses
+    SET fetch_status = 'running', fetch_started_at = ?, error_message = NULL, article_count = 0, last_updated_at = ?
+    WHERE scan_id = ? AND source_id = ?
+  `);
+
+  const finishFetchSuccess = db.prepare(`
+    UPDATE scan_source_statuses
+    SET fetch_status = 'success', fetch_completed_at = ?, article_count = ?, error_message = NULL, last_updated_at = ?
+    WHERE scan_id = ? AND source_id = ?
+  `);
+
+  const finishFetchError = db.prepare(`
+    UPDATE scan_source_statuses
+    SET fetch_status = 'error', fetch_completed_at = ?, article_count = ?, error_message = ?, last_updated_at = ?
+    WHERE scan_id = ? AND source_id = ?
+  `);
+
+  const updateArticleCount = db.prepare(`
+    UPDATE scan_source_statuses
+    SET article_count = ?, last_updated_at = ?
+    WHERE scan_id = ? AND source_id = ?
+  `);
+
+  ensureStatusRow.run(scanId, OPENAI_SOURCE_ID, startedAt);
+  db.prepare(`
+    UPDATE scan_source_statuses
+    SET fetch_status = 'n/a', classification_status = 'pending', translation_status = 'pending',
+        summarization_status = 'pending', openai_connected = NULL, openai_error = NULL, last_updated_at = ?
+    WHERE scan_id = ? AND source_id = ?
+  `).run(startedAt, scanId, OPENAI_SOURCE_ID);
+
+  const setOpenAIStatus = (fields = {}) => {
+    const keys = Object.keys(fields);
+    if (!keys.length) return;
+    const assignments = keys.map((key) => `${key} = ?`).join(", ");
+    const stmt = db.prepare(`
+      UPDATE scan_source_statuses
+      SET ${assignments}, last_updated_at = ?
+      WHERE scan_id = ? AND source_id = ?
+    `);
+    stmt.run(...keys.map((key) => fields[key]), now(), scanId, OPENAI_SOURCE_ID);
+  };
 
   // Ensure sources table is seeded
   for (const s of getAllSources()) {
@@ -24,116 +83,223 @@ export async function runFullScan({ manual=false } = {}) {
                 VALUES (@id, @name, @region, @tier, @homepage_url, 1)`).run(s);
   }
 
-  // 1) Fetch feeds
+  const enabledSources = Array.from(getEnabledSources());
   const rawItems = [];
-  for (const src of getEnabledSources()) {
-    for (const feed of (src.feeds || [])) {
-      const items = await fetchFeed(feed.url);
-      for (const it of items) {
-        const url = it.link || it.guid || "";
-        if (!url) continue;
-        rawItems.push({
-          source_id: src.id,
-          source_name: src.name,
-          url,
-          title_zh: normalizeTitle(it.title || ""),
-          dek_zh: normalizeTitle(it.contentSnippet || it.content || ""),
-          published_at: it.isoDate || it.pubDate || null,
-          fetched_at: startedAt,
-          section_hint: feed.section_hint || "mixed"
-        });
+  let items = [];
+  let classificationPhase = 'pending';
+  let translationPhase = 'pending';
+  let summarizationPhase = 'pending';
+  let lastOpenAIError = null;
+
+  try {
+    // 1) Fetch feeds
+    for (const src of enabledSources) {
+      ensureStatusRow.run(scanId, src.id, startedAt);
+      const fetchStartedAt = now();
+      startFetch.run(fetchStartedAt, fetchStartedAt, scanId, src.id);
+      let totalForSource = 0;
+      let lastError = null;
+      for (const feed of (src.feeds || [])) {
+        try {
+          const feedItems = await fetchFeed(feed.url);
+          totalForSource += feedItems.length;
+          for (const it of feedItems) {
+            const url = it.link || it.guid || "";
+            if (!url) continue;
+            rawItems.push({
+              source_id: src.id,
+              source_name: src.name,
+              url,
+              title_zh: normalizeTitle(it.title || ""),
+              dek_zh: normalizeTitle(it.contentSnippet || it.content || ""),
+              published_at: it.isoDate || it.pubDate || null,
+              fetched_at: startedAt,
+              section_hint: feed.section_hint || "mixed"
+            });
+          }
+        } catch (err) {
+          lastError = truncateError(err);
+        }
+      }
+      const fetchCompletedAt = now();
+      if (lastError) {
+        finishFetchError.run(fetchCompletedAt, totalForSource, lastError, fetchCompletedAt, scanId, src.id);
+      } else {
+        finishFetchSuccess.run(fetchCompletedAt, totalForSource, fetchCompletedAt, scanId, src.id);
       }
     }
-  }
 
-  // 2) Deduplicate by URL + title
-  const seen = new Set();
-  const items = [];
-  for (const it of rawItems) {
-    const key = it.url + "|" + it.title_zh;
-    if (seen.has(key)) continue;
-    seen.add(key);
-    items.push(it);
-  }
-
-  // 3) Persist articles
-  for (const it of items) {
-    const id = articleIdFrom(it.url, it.title_zh);
-    it.id = id;
-    db.prepare(`INSERT OR IGNORE INTO articles
-        (id, source_id, url, title_zh, dek_zh, published_at, fetched_at, section_hint, hash)
-        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`)
-      .run(id, it.source_id, it.url, it.title_zh, it.dek_zh, it.published_at, it.fetched_at, it.section_hint, hashStable(it.url));
-  }
-
-  // 4) Classification
-  const classification = await classifyItems(config.OPENAI_MODEL, items);
-  const catByUrl = new Map();
-  for (const row of (classification.items || [])) {
-    catByUrl.set(row.url, { category: row.category, confidence: row.confidence ?? 0.5 });
-  }
-  for (const it of items) {
-    const cat = catByUrl.get(it.url) || { category: "society", confidence: 0.4 };
-    db.prepare(`INSERT OR REPLACE INTO classifications (article_id, category, confidence, method, created_at)
-                VALUES (?, ?, ?, ?, ?)`)
-      .run(it.id, cat.category, cat.confidence, "openai_structured", startedAt);
-  }
-
-  // 5) Translation
-  const translation = await translateItems(config.OPENAI_MODEL, items);
-  const tByUrl = new Map();
-  for (const row of (translation.translations || [])) {
-    tByUrl.set(row.url, { title_en: row.title_en, dek_en: row.dek_en || "" });
-  }
-  for (const it of items) {
-    const tr = tByUrl.get(it.url);
-    if (tr) {
-      db.prepare(`INSERT OR REPLACE INTO translations (article_id, title_en, dek_en, engine, created_at)
-                  VALUES (?, ?, ?, ?, ?)`)
-        .run(it.id, tr.title_en, tr.dek_en, "openai", startedAt);
+    // 2) Deduplicate by URL + title
+    const seen = new Set();
+    items = [];
+    for (const it of rawItems) {
+      const key = it.url + "|" + it.title_zh;
+      if (seen.has(key)) continue;
+      seen.add(key);
+      items.push(it);
     }
-  }
 
-  // 6) Build scan_items ranked per category
-  const itemsWithCat = items.map(it => {
-    const row = db.prepare("SELECT category FROM classifications WHERE article_id = ?").get(it.id);
-    return { ...it, category: row?.category || "society" };
-  });
-  const byCat = groupBy(itemsWithCat, (x) => x.category);
-  for (const [cat, list] of byCat.entries()) {
-    // rank by source centrality then published time
-    list.sort((a, b) => (a.source_id.includes("people") ? -1 : 0) - (b.source_id.includes("people") ? -1 : 0)
-      || String(b.published_at || "").localeCompare(String(a.published_at || "")));
-    let rank = 1;
-    for (const it of list) {
-      db.prepare(`INSERT OR REPLACE INTO scan_items (scan_id, article_id, category, rank_in_category, is_duplicate, cluster_id)
-                  VALUES (?, ?, ?, ?, 0, NULL)`)
-        .run(scanId, it.id, cat, rank++);
+    const dedupCounts = new Map();
+    for (const it of items) {
+      dedupCounts.set(it.source_id, (dedupCounts.get(it.source_id) || 0) + 1);
     }
-  }
+    const dedupAt = now();
+    for (const src of enabledSources) {
+      updateArticleCount.run(dedupCounts.get(src.id) || 0, dedupAt, scanId, src.id);
+    }
 
-  // 7) Summaries per category
-  for (const category of ["international","domestic_politics","business","society","technology","military","science","opinion"]) {
-    const rows = db.prepare(`
-      SELECT a.*, s.name as source_name, t.title_en
-      FROM scan_items si
-      JOIN articles a ON a.id = si.article_id
-      JOIN sources s ON s.id = a.source_id
-      LEFT JOIN translations t ON t.article_id = a.id
-      WHERE si.scan_id = ? AND si.category = ?
-      ORDER BY si.rank_in_category ASC
-      LIMIT 20
-    `).all(scanId, category);
-    if (!rows.length) continue;
-    const summary = await summarizeCategory(config.OPENAI_MODEL, startedAt, category, rows);
-    db.prepare(`INSERT OR REPLACE INTO summaries (scan_id, category, json_payload, created_at)
-                VALUES (?, ?, ?, ?)`)
-      .run(scanId, category, JSON.stringify(summary), startedAt);
-  }
+    // 3) Persist articles
+    for (const it of items) {
+      const id = articleIdFrom(it.url, it.title_zh);
+      it.id = id;
+      db.prepare(`INSERT OR IGNORE INTO articles
+          (id, source_id, url, title_zh, dek_zh, published_at, fetched_at, section_hint, hash)
+          VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`)
+        .run(id, it.source_id, it.url, it.title_zh, it.dek_zh, it.published_at, it.fetched_at, it.section_hint, hashStable(it.url));
+    }
 
-  const completedAt = dayjs().tz(config.TZ).toISOString();
-  db.prepare("UPDATE scans SET run_completed_at = ?, total_articles = ? WHERE id = ?")
-    .run(completedAt, items.length, scanId);
+    if (items.length === 0) {
+      classificationPhase = 'skipped';
+      translationPhase = 'skipped';
+      summarizationPhase = 'skipped';
+      lastOpenAIError = null;
+      setOpenAIStatus({
+        classification_status: 'skipped',
+        translation_status: 'skipped',
+        summarization_status: 'skipped',
+        openai_connected: null,
+        openai_error: null
+      });
+    } else {
+      // 4) Classification
+      try {
+        classificationPhase = 'running';
+        lastOpenAIError = null;
+        setOpenAIStatus({ classification_status: 'running', openai_error: null });
+        const classification = await classifyItems(config.OPENAI_MODEL, items);
+        classificationPhase = 'success';
+        setOpenAIStatus({ classification_status: 'success', openai_connected: 1 });
+        const catByUrl = new Map();
+        for (const row of (classification.items || [])) {
+          catByUrl.set(row.url, { category: row.category, confidence: row.confidence ?? 0.5 });
+        }
+        for (const it of items) {
+          const cat = catByUrl.get(it.url) || { category: "society", confidence: 0.4 };
+          db.prepare(`INSERT OR REPLACE INTO classifications (article_id, category, confidence, method, created_at)
+                      VALUES (?, ?, ?, ?, ?)`)
+            .run(it.id, cat.category, cat.confidence, "openai_structured", startedAt);
+        }
+      } catch (err) {
+        classificationPhase = 'error';
+        lastOpenAIError = truncateError(err);
+        setOpenAIStatus({ classification_status: 'error', openai_connected: 0, openai_error: lastOpenAIError });
+        throw err;
+      }
+
+      // 5) Translation
+      let translations;
+      try {
+        translationPhase = 'running';
+        lastOpenAIError = null;
+        setOpenAIStatus({ translation_status: 'running', openai_error: null });
+        translations = await translateItems(config.OPENAI_MODEL, items);
+        translationPhase = 'success';
+        setOpenAIStatus({ translation_status: 'success', openai_connected: 1 });
+      } catch (err) {
+        translationPhase = 'error';
+        lastOpenAIError = truncateError(err);
+        setOpenAIStatus({ translation_status: 'error', openai_connected: 0, openai_error: lastOpenAIError });
+        throw err;
+      }
+      const tByUrl = new Map();
+      for (const row of (translations?.translations || [])) {
+        tByUrl.set(row.url, { title_en: row.title_en, dek_en: row.dek_en || "" });
+      }
+      for (const it of items) {
+        const tr = tByUrl.get(it.url);
+        if (tr) {
+          db.prepare(`INSERT OR REPLACE INTO translations (article_id, title_en, dek_en, engine, created_at)
+                      VALUES (?, ?, ?, ?, ?)`)
+            .run(it.id, tr.title_en, tr.dek_en, "openai", startedAt);
+        }
+      }
+
+      // 6) Build scan_items ranked per category + summaries
+      try {
+        summarizationPhase = 'running';
+        lastOpenAIError = null;
+        setOpenAIStatus({ summarization_status: 'running', openai_error: null });
+        const itemsWithCat = items.map(it => {
+          const row = db.prepare("SELECT category FROM classifications WHERE article_id = ?").get(it.id);
+          return { ...it, category: row?.category || "society" };
+        });
+        const byCat = groupBy(itemsWithCat, (x) => x.category);
+        for (const [cat, list] of byCat.entries()) {
+          list.sort((a, b) => (a.source_id.includes("people") ? -1 : 0) - (b.source_id.includes("people") ? -1 : 0)
+            || String(b.published_at || "").localeCompare(String(a.published_at || "")));
+          let rank = 1;
+          for (const it of list) {
+            db.prepare(`INSERT OR REPLACE INTO scan_items (scan_id, article_id, category, rank_in_category, is_duplicate, cluster_id)
+                        VALUES (?, ?, ?, ?, 0, NULL)`)
+              .run(scanId, it.id, cat, rank++);
+          }
+        }
+
+        for (const category of ["international","domestic_politics","business","society","technology","military","science","opinion"]) {
+          const rows = db.prepare(`
+            SELECT a.*, s.name as source_name, t.title_en
+            FROM scan_items si
+            JOIN articles a ON a.id = si.article_id
+            JOIN sources s ON s.id = a.source_id
+            LEFT JOIN translations t ON t.article_id = a.id
+            WHERE si.scan_id = ? AND si.category = ?
+            ORDER BY si.rank_in_category ASC
+            LIMIT 20
+          `).all(scanId, category);
+          if (!rows.length) continue;
+          const summary = await summarizeCategory(config.OPENAI_MODEL, startedAt, category, rows);
+          db.prepare(`INSERT OR REPLACE INTO summaries (scan_id, category, json_payload, created_at)
+                      VALUES (?, ?, ?, ?)`)
+            .run(scanId, category, JSON.stringify(summary), startedAt);
+        }
+        summarizationPhase = 'success';
+        setOpenAIStatus({ summarization_status: 'success', openai_connected: 1 });
+      } catch (err) {
+        summarizationPhase = 'error';
+        lastOpenAIError = truncateError(err);
+        setOpenAIStatus({ summarization_status: 'error', openai_connected: 0, openai_error: lastOpenAIError });
+        throw err;
+      }
+    }
+
+    const completedAt = now();
+    db.prepare("UPDATE scans SET run_completed_at = ?, total_articles = ?, status = ? WHERE id = ?")
+      .run(completedAt, items.length, 'complete', scanId);
+  } catch (err) {
+    const failedAt = now();
+    const failureMessage = truncateError(err);
+    lastOpenAIError = failureMessage;
+    const fields = {
+      openai_connected: 0,
+      openai_error: failureMessage
+    };
+    if (classificationPhase === 'pending' || classificationPhase === 'running') {
+      fields.classification_status = 'error';
+      classificationPhase = 'error';
+    }
+    if (translationPhase === 'pending' || translationPhase === 'running') {
+      fields.translation_status = 'error';
+      translationPhase = 'error';
+    }
+    if (summarizationPhase === 'pending' || summarizationPhase === 'running') {
+      fields.summarization_status = 'error';
+      summarizationPhase = 'error';
+    }
+    setOpenAIStatus(fields);
+    db.prepare("UPDATE scans SET status = ?, run_completed_at = ?, total_articles = ? WHERE id = ?")
+      .run('failed', failedAt, items.length, scanId);
+    throw err;
+  }
 
   return { id: scanId };
 }

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "beijing-brief-web",
+  "name": "china-compass-web",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "beijing-brief-web",
+      "name": "china-compass-web",
       "version": "0.1.0",
       "dependencies": {
         "@vitejs/plugin-react": "^5.0.4",

--- a/web/src/components/StatusBar.tsx
+++ b/web/src/components/StatusBar.tsx
@@ -1,0 +1,215 @@
+import { useCallback, useEffect, useMemo, useState } from 'react'
+
+type SourceStatus = {
+  source_id: string
+  source_name: string
+  fetch_status: string
+  fetch_started_at?: string | null
+  fetch_completed_at?: string | null
+  article_count: number
+  error_message?: string | null
+  last_updated_at: string
+  source_region?: string | null
+  source_tier?: string | null
+}
+
+type OpenAIStatus = {
+  classification_status?: string | null
+  translation_status?: string | null
+  summarization_status?: string | null
+  openai_connected?: number | null
+  openai_error?: string | null
+  last_updated_at?: string | null
+}
+
+type ScanMeta = {
+  id: string
+  run_started_at: string
+  run_completed_at?: string | null
+  schedule_kind?: string | null
+  timezone?: string | null
+  total_articles?: number | null
+  status?: string | null
+}
+
+type StatusResponse = {
+  scan: ScanMeta
+  sources: SourceStatus[]
+  openai?: OpenAIStatus | null
+}
+
+type Tone = 'success' | 'running' | 'danger' | 'warning' | 'neutral'
+
+const POLL_INTERVAL_MS = 15000
+
+const TONE_STYLES: Record<Tone, { badge: string; dot: string }> = {
+  success: {
+    badge: 'border-emerald-400/40 bg-emerald-500/20 text-emerald-100',
+    dot: 'bg-emerald-400'
+  },
+  running: {
+    badge: 'border-sky-400/40 bg-sky-500/20 text-sky-100',
+    dot: 'bg-sky-400'
+  },
+  danger: {
+    badge: 'border-rose-400/40 bg-rose-500/20 text-rose-100',
+    dot: 'bg-rose-400'
+  },
+  warning: {
+    badge: 'border-amber-400/40 bg-amber-500/20 text-amber-100',
+    dot: 'bg-amber-300'
+  },
+  neutral: {
+    badge: 'border-slate-400/40 bg-slate-600/40 text-slate-100',
+    dot: 'bg-slate-300'
+  }
+}
+
+function toneForStatus(status?: string | null): Tone {
+  switch (status) {
+    case 'success':
+    case 'complete':
+      return 'success'
+    case 'running':
+      return 'running'
+    case 'error':
+    case 'failed':
+      return 'danger'
+    case 'pending':
+      return 'warning'
+    default:
+      return 'neutral'
+  }
+}
+
+function formatDateTime(value?: string | null) {
+  if (!value) return null
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) return null
+  return date.toLocaleString()
+}
+
+function summarizeRun(scan: ScanMeta) {
+  const schedule = scan.schedule_kind === 'manual' ? 'Manual' : 'Auto'
+  const started = formatDateTime(scan.run_started_at)
+  const completed = formatDateTime(scan.run_completed_at)
+  switch (scan.status) {
+    case 'running':
+      return `${schedule} run in progress${started ? ` — started ${started}` : ''}`
+    case 'failed':
+      return `${schedule} run failed${completed ? ` — ${completed}` : ''}`
+    case 'complete':
+    default:
+      return `${schedule} run completed${completed ? ` — ${completed}` : started ? ` — started ${started}` : ''}`
+  }
+}
+
+function summarizeAI(status?: OpenAIStatus | null) {
+  if (!status) return { text: 'AI status unavailable', tone: 'neutral' as Tone }
+  const phases = [status.classification_status, status.translation_status, status.summarization_status]
+  if (phases.every(p => p === 'skipped')) {
+    return { text: 'AI phases skipped (no articles)', tone: 'neutral' as Tone }
+  }
+  if (phases.some(p => p === 'error') || status.openai_connected === 0) {
+    return {
+      text: status.openai_error ? `AI error: ${status.openai_error}` : 'AI phases failed',
+      tone: 'danger' as Tone
+    }
+  }
+  if (phases.some(p => p === 'running')) {
+    return { text: 'AI processing…', tone: 'running' as Tone }
+  }
+  if (phases.every(p => p === 'success')) {
+    return { text: 'AI responses healthy', tone: 'success' as Tone }
+  }
+  return { text: 'AI status pending', tone: 'warning' as Tone }
+}
+
+export default function StatusBar() {
+  const [status, setStatus] = useState<StatusResponse | null>(null)
+  const [state, setState] = useState<'loading' | 'ready' | 'empty' | 'error'>('loading')
+  const [error, setError] = useState<string | null>(null)
+
+  const load = useCallback(async () => {
+    try {
+      const response = await fetch('/api/status', { cache: 'no-store' })
+      if (response.status === 404) {
+        setStatus(null)
+        setState('empty')
+        setError(null)
+        return
+      }
+      if (!response.ok) {
+        throw new Error(`Request failed with status ${response.status}`)
+      }
+      const data: StatusResponse = await response.json()
+      setStatus(data)
+      setState('ready')
+      setError(null)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err))
+      setState('error')
+    }
+  }, [])
+
+  useEffect(() => {
+    load()
+    const id = setInterval(load, POLL_INTERVAL_MS)
+    return () => clearInterval(id)
+  }, [load])
+
+  const runTone = toneForStatus(status?.scan.status || (state === 'empty' ? 'pending' : undefined))
+  const runText = status ? summarizeRun(status.scan) : state === 'empty' ? 'Awaiting first scan' : 'Loading run status…'
+  const aiSummary = useMemo(() => summarizeAI(status?.openai), [status])
+
+  return (
+    <div className="pointer-events-none fixed inset-x-0 bottom-0 z-40 border-t border-slate-800/80 bg-slate-950/90 backdrop-blur">
+      <div className="pointer-events-auto mx-auto flex max-w-7xl flex-col gap-3 px-4 py-3 text-xs text-slate-100 sm:flex-row sm:items-center sm:justify-between">
+        <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:gap-3">
+          <span className={`inline-flex items-center gap-2 rounded-full border px-3 py-1 font-medium ${TONE_STYLES[runTone].badge}`}>
+            <span className={`h-2 w-2 rounded-full ${TONE_STYLES[runTone].dot}`} aria-hidden="true" />
+            {runText}
+          </span>
+          {status?.scan.total_articles != null && status.scan.status === 'complete' && (
+            <span className="rounded-full border border-slate-700/60 bg-slate-800/60 px-3 py-1 font-medium text-slate-200">
+              {status.scan.total_articles} articles
+            </span>
+          )}
+        </div>
+
+        <div className="flex w-full flex-col gap-2 sm:w-auto sm:flex-1 sm:flex-row sm:items-center sm:justify-end">
+          <span className={`inline-flex max-w-full items-center gap-2 rounded-full border px-3 py-1 font-medium ${TONE_STYLES[aiSummary.tone].badge}`} title={status?.openai?.openai_error || undefined}>
+            <span className={`h-2 w-2 rounded-full ${TONE_STYLES[aiSummary.tone].dot}`} aria-hidden="true" />
+            <span className="truncate">{aiSummary.text}</span>
+          </span>
+
+          <div className="-mx-1 flex items-center gap-2 overflow-x-auto px-1">
+            {state === 'loading' && <span className="whitespace-nowrap text-slate-300/80">Checking sources…</span>}
+            {state === 'error' && <span className="whitespace-nowrap text-rose-200">Status unavailable: {error}</span>}
+            {state !== 'loading' && state !== 'error' && status?.sources.length ? (
+              status.sources.map(source => {
+                const tone = toneForStatus(source.fetch_status)
+                const tooltip = `${source.source_name} — ${source.fetch_status.toUpperCase()}${source.article_count != null ? ` • ${source.article_count} articles` : ''}${source.error_message ? ` • ${source.error_message}` : ''}`
+                return (
+                  <span
+                    key={source.source_id}
+                    className={`inline-flex shrink-0 items-center gap-2 rounded-full border px-3 py-1 font-medium ${TONE_STYLES[tone].badge}`}
+                    title={tooltip}
+                  >
+                    <span className={`h-2 w-2 rounded-full ${TONE_STYLES[tone].dot}`} aria-hidden="true" />
+                    <span className="truncate">{source.source_name}</span>
+                    <span className="text-[0.65rem] uppercase tracking-wide text-slate-200/70">{source.article_count}</span>
+                  </span>
+                )
+              })
+            ) : state === 'empty' ? (
+              <span className="whitespace-nowrap text-slate-300/80">No scan activity yet</span>
+            ) : state === 'ready' && status ? (
+              <span className="whitespace-nowrap text-slate-300/80">Per-source status unavailable</span>
+            ) : null}
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/web/src/pages/Today.tsx
+++ b/web/src/pages/Today.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useState } from 'react'
 import Header from '../components/Header'
 import CategoryColumn from '../components/CategoryColumn'
 import SummaryCard from '../components/SummaryCard'
+import StatusBar from '../components/StatusBar'
 
 type ScanPayload = {
   meta: { id: string, run_started_at: string }
@@ -56,7 +57,7 @@ export default function Today() {
   return (
     <div className="min-h-screen bg-slate-50">
       <Header onRescan={rescan} lastRun={data?.meta.run_started_at} />
-      <main className="max-w-7xl mx-auto px-4 pb-10">
+      <main className="max-w-7xl mx-auto px-4 pb-28">
         {error && <div className="p-3 border rounded bg-yellow-50 text-sm">{error}</div>}
         {!data ? <div className="mt-10 text-center text-sm text-slate-600">Loading…</div> : (
           <>
@@ -112,6 +113,7 @@ export default function Today() {
           </>
         )}
       </main>
+      <StatusBar />
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- add a scan_source_statuses table and scan status column to persist run metadata
- update the full scan job to log per-source fetch progress and OpenAI phase outcomes
- expose /api/status and surface the data with a polling StatusBar in the Today page

## Testing
- npm --prefix web run build

------
https://chatgpt.com/codex/tasks/task_e_68ddca3a46588331ae3de6e7602773f9