### PR TITLE
Update homepage feeds for major publications

### DIFF
--- a/server/src/feeds/sources.json
+++ b/server/src/feeds/sources.json
@@ -8,7 +8,7 @@
     "feeds": [
       {
         "name": "front_page",
-        "url": "http://www.people.com.cn/rss/index.xml",
+        "url": "https://www.people.com.cn/rss/index.xml",
         "section_hint": "mixed"
       }
     ]
@@ -64,7 +64,7 @@
     "feeds": [
       {
         "name": "front_page",
-        "url": "https://www.globaltimes.cn/rss/topnews.xml",
+        "url": "https://www.globaltimes.cn/rss/index.xml",
         "section_hint": "mixed"
       }
     ]


### PR DESCRIPTION
## Summary
- point the People’s Daily source to the HTTPS homepage feed
- use the Global Times homepage feed instead of the Top News section

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68de6e3c62388331b149306de6fc1b01