### PR TITLE
Add English translation support to Today page feeds

### DIFF
--- a/web/src/components/CategoryColumn.tsx
+++ b/web/src/components/CategoryColumn.tsx
@@ -1,16 +1,26 @@
 import { useMemo, useState } from 'react'
 
-type Item = {
+export type CategoryItem = {
+  id: string
   url: string
   source_name: string
   title_zh: string
   title_en?: string
+  dek_zh?: string
+  dek_en?: string
   published_at?: string
+  source_id?: string
+  fetched_at?: string
+  section_hint?: string
+  hash?: string
+  category?: string
+  rank_in_category?: number
+  is_duplicate?: boolean
 }
 
-export default function CategoryColumn({ title, items }: { title: string, items: Item[] }) {
+export default function CategoryColumn({ title, items }: { title: string, items: CategoryItem[] }) {
   const [showEnglish, setShowEnglish] = useState(false)
-  const hasTranslations = useMemo(() => items.some(it => !!it.title_en), [items])
+  const hasTranslations = useMemo(() => items.some(it => !!(it.title_en || it.dek_en)), [items])
 
   function formatTime(value?: string) {
     if (!value) return null
@@ -45,6 +55,7 @@ export default function CategoryColumn({ title, items }: { title: string, items:
         )}
         {items.map((it, idx) => {
           const time = formatTime(it.published_at)
+          const englishText = it.title_en || it.dek_en
           return (
             <li key={it.url + idx} className="group">
               <a
@@ -62,8 +73,8 @@ export default function CategoryColumn({ title, items }: { title: string, items:
                 <p className="mt-2 text-sm font-medium leading-snug text-slate-900 group-hover:text-slate-950">
                   {it.title_zh}
                 </p>
-                {showEnglish && it.title_en && (
-                  <p className="mt-1 text-sm leading-relaxed text-slate-600">{it.title_en}</p>
+                {showEnglish && englishText && (
+                  <p className="mt-1 text-sm leading-relaxed text-slate-600">{englishText}</p>
                 )}
               </a>
             </li>

--- a/web/src/pages/Today.tsx
+++ b/web/src/pages/Today.tsx
@@ -1,12 +1,12 @@
 import { useEffect, useMemo, useState } from 'react'
 import Header from '../components/Header'
-import CategoryColumn from '../components/CategoryColumn'
+import CategoryColumn, { type CategoryItem } from '../components/CategoryColumn'
 import SummaryCard from '../components/SummaryCard'
 import StatusBar from '../components/StatusBar'
 
 type ScanPayload = {
   meta: { id: string, run_started_at: string }
-  categories: Record<string, any[]>
+  categories: Record<string, CategoryItem[]>
   summaries: Record<string, any>
 }
 


### PR DESCRIPTION
## Summary
- join the translations table when loading scan items so English titles and deks are available
- ensure serialized category items include the English translation fields alongside existing article metadata
- allow the Today category column toggle to surface English headlines (or deks) and type results precisely

## Testing
- npm run install
- Manually launched the Express API and Vite dev servers and opened the Today page

------
https://chatgpt.com/codex/tasks/task_e_68df9314023483319a266f866fba8c9a