### PR TITLE
Add uncategorized fallback category for Today page

### DIFF
--- a/web/src/pages/Today.tsx
+++ b/web/src/pages/Today.tsx
@@ -18,7 +18,8 @@ const CAT_LABELS: Record<string,string> = {
   technology: "Technology",
   military: "Military/Defense",
   science: "Science/Research",
-  opinion: "Opinion/Commentary"
+  opinion: "Opinion/Commentary",
+  uncategorized: "Uncategorized"
 }
 
 export default function Today() {


### PR DESCRIPTION
## Summary
- add an "Uncategorized" label to the Today page category list so unexpected scan buckets render

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68df958aae98833182fad89add2933b5