### PR TITLE
Enhance log view with selectable run details

### DIFF
--- a/web/src/components/ExpandableSection.tsx
+++ b/web/src/components/ExpandableSection.tsx
@@ -1,0 +1,42 @@
+import type { PropsWithChildren, ReactNode } from 'react'
+
+export default function ExpandableSection({
+  title,
+  description,
+  defaultOpen = false,
+  actions,
+  children
+}: PropsWithChildren<{
+  title: string
+  description?: ReactNode
+  defaultOpen?: boolean
+  actions?: ReactNode
+}>) {
+  return (
+    <details
+      className="group overflow-hidden rounded-3xl border border-slate-200 bg-white shadow-sm"
+      open={defaultOpen}
+    >
+      <summary
+        className="flex cursor-pointer list-none items-center justify-between gap-4 px-6 py-4 text-left outline-none marker:content-none"
+      >
+        <div>
+          <h3 className="text-base font-semibold text-slate-900">{title}</h3>
+          {description && <p className="mt-1 text-sm text-slate-600">{description}</p>}
+        </div>
+        <div className="flex items-center gap-3">
+          {actions}
+          <span
+            aria-hidden
+            className="inline-flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-full bg-slate-100 text-base font-medium text-slate-600 transition-transform duration-200 group-open:rotate-45"
+          >
+            +
+          </span>
+        </div>
+      </summary>
+      <div className="border-t border-slate-200 px-6 py-5 text-sm leading-6 text-slate-700">
+        {children}
+      </div>
+    </details>
+  )
+}

--- a/web/src/components/RunDetailPanel.tsx
+++ b/web/src/components/RunDetailPanel.tsx
@@ -1,0 +1,112 @@
+import { useMemo } from 'react'
+import CategoryColumn, { type CategoryItem } from './CategoryColumn'
+import SummaryCard from './SummaryCard'
+import ExpandableSection from './ExpandableSection'
+import { CATEGORY_LABELS, CATEGORY_ORDER } from './categoryLabels'
+
+type RunMeta = {
+  id: string
+  run_started_at: string
+  run_completed_at?: string | null
+  schedule_kind?: string | null
+  timezone?: string | null
+  total_articles?: number | null
+}
+
+type RunDetail = {
+  meta: RunMeta
+  categories: Record<string, CategoryItem[]>
+  summaries: Record<string, any>
+}
+
+function formatDateTime(value?: string | null) {
+  if (!value) return '—'
+  try {
+    return new Date(value).toLocaleString()
+  } catch (err) {
+    return value
+  }
+}
+
+function formatDuration(start?: string | null, end?: string | null) {
+  if (!start || !end) return null
+  try {
+    const diff = Math.max(0, new Date(end).getTime() - new Date(start).getTime())
+    const minutes = Math.round(diff / 60000)
+    if (minutes < 1) return '<1 minute'
+    if (minutes === 1) return '1 minute'
+    if (minutes < 60) return `${minutes} minutes`
+    const hours = minutes / 60
+    if (hours < 10) return `${hours.toFixed(hours % 1 === 0 ? 0 : 1)} hours`
+    const wholeHours = Math.round(hours)
+    return `${wholeHours} hours`
+  } catch (err) {
+    return null
+  }
+}
+
+export default function RunDetailPanel({ data }: { data: RunDetail }) {
+  const { meta } = data
+  const duration = useMemo(() => formatDuration(meta.run_started_at, meta.run_completed_at), [meta.run_started_at, meta.run_completed_at])
+
+  return (
+    <div className="space-y-6">
+      <section className="rounded-3xl border border-slate-200 bg-gradient-to-br from-slate-50 via-white to-white px-6 py-6 shadow-sm">
+        <header className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+          <div>
+            <h2 className="text-xl font-semibold text-slate-900">Run metadata</h2>
+            <p className="mt-1 text-sm text-slate-600">Detailed timing and totals captured for this scan.</p>
+          </div>
+          <span className="inline-flex items-center rounded-full bg-slate-900/90 px-3 py-1 text-xs font-medium uppercase tracking-wide text-white">
+            {meta.schedule_kind ? meta.schedule_kind.replace(/_/g, ' ') : 'unspecified'}
+          </span>
+        </header>
+        <dl className="mt-5 grid gap-4 text-sm sm:grid-cols-2 lg:grid-cols-3">
+          <div className="rounded-2xl border border-slate-200 bg-white px-4 py-3">
+            <dt className="text-xs uppercase tracking-wide text-slate-500">Run ID</dt>
+            <dd className="mt-1 font-medium text-slate-900 break-all">{meta.id}</dd>
+          </div>
+          <div className="rounded-2xl border border-slate-200 bg-white px-4 py-3">
+            <dt className="text-xs uppercase tracking-wide text-slate-500">Started</dt>
+            <dd className="mt-1 font-medium text-slate-900">{formatDateTime(meta.run_started_at)}</dd>
+          </div>
+          <div className="rounded-2xl border border-slate-200 bg-white px-4 py-3">
+            <dt className="text-xs uppercase tracking-wide text-slate-500">Completed</dt>
+            <dd className="mt-1 font-medium text-slate-900">{formatDateTime(meta.run_completed_at)}</dd>
+          </div>
+          <div className="rounded-2xl border border-slate-200 bg-white px-4 py-3">
+            <dt className="text-xs uppercase tracking-wide text-slate-500">Duration</dt>
+            <dd className="mt-1 font-medium text-slate-900">{duration || '—'}</dd>
+          </div>
+          <div className="rounded-2xl border border-slate-200 bg-white px-4 py-3">
+            <dt className="text-xs uppercase tracking-wide text-slate-500">Total articles</dt>
+            <dd className="mt-1 font-medium text-slate-900">{meta.total_articles ?? '—'}</dd>
+          </div>
+          <div className="rounded-2xl border border-slate-200 bg-white px-4 py-3">
+            <dt className="text-xs uppercase tracking-wide text-slate-500">Timezone</dt>
+            <dd className="mt-1 font-medium text-slate-900">{meta.timezone || '—'}</dd>
+          </div>
+        </dl>
+      </section>
+
+      <ExpandableSection title="Summaries" description="High-level takeaways generated for each category." defaultOpen>
+        <div className="grid gap-6 md:grid-cols-2">
+          {CATEGORY_ORDER.map(key => (
+            <SummaryCard key={key} title={CATEGORY_LABELS[key] || key} data={data.summaries[key]} />
+          ))}
+        </div>
+        {Object.keys(data.summaries || {}).length === 0 && (
+          <p className="text-sm text-slate-500">No summaries recorded for this run.</p>
+        )}
+      </ExpandableSection>
+
+      <ExpandableSection title="Article coverage" description="Captured source articles grouped by category." defaultOpen>
+        <div className="grid gap-6 md:grid-cols-2 xl:grid-cols-3">
+          {CATEGORY_ORDER.map(key => (
+            <CategoryColumn key={key} title={CATEGORY_LABELS[key] || key} items={data.categories[key] || []} />
+          ))}
+        </div>
+      </ExpandableSection>
+    </div>
+  )
+}

--- a/web/src/components/categoryLabels.ts
+++ b/web/src/components/categoryLabels.ts
@@ -1,0 +1,23 @@
+export const CATEGORY_ORDER = [
+  'international',
+  'domestic_politics',
+  'business',
+  'society',
+  'technology',
+  'military',
+  'science',
+  'opinion',
+  'uncategorized'
+] as const
+
+export const CATEGORY_LABELS: Record<(typeof CATEGORY_ORDER)[number], string> = {
+  international: 'International',
+  domestic_politics: 'Domestic Politics',
+  business: 'Business/Economy',
+  society: 'Society',
+  technology: 'Technology',
+  military: 'Military/Defense',
+  science: 'Science/Research',
+  opinion: 'Opinion/Commentary',
+  uncategorized: 'Uncategorized'
+}

--- a/web/src/pages/Log.tsx
+++ b/web/src/pages/Log.tsx
@@ -1,44 +1,202 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import Header from '../components/Header'
+import RunDetailPanel from '../components/RunDetailPanel'
+import type { CategoryItem } from '../components/CategoryColumn'
 
-type ScanMeta = { id: string, run_started_at: string, run_completed_at: string, total_articles: number, schedule_kind: string }
+type ScanMeta = {
+  id: string
+  run_started_at: string
+  run_completed_at?: string | null
+  total_articles: number
+  schedule_kind: string
+}
+
+type ScanDetail = {
+  meta: {
+    id: string
+    run_started_at: string
+    run_completed_at?: string | null
+    total_articles?: number | null
+    schedule_kind?: string | null
+    timezone?: string | null
+  }
+  categories: Record<string, CategoryItem[]>
+  summaries: Record<string, any>
+}
 
 export default function Log() {
   const [items, setItems] = useState<ScanMeta[]>([])
+  const [selectedId, setSelectedId] = useState<string | null>(null)
+  const [details, setDetails] = useState<Record<string, ScanDetail>>({})
+  const [loadingId, setLoadingId] = useState<string | null>(null)
+  const [detailError, setDetailError] = useState<string | null>(null)
 
-  async function load() {
+  const orderedItems = useMemo(() => items.slice().sort((a, b) => {
+    return new Date(b.run_started_at).getTime() - new Date(a.run_started_at).getTime()
+  }), [items])
+
+  async function loadList() {
     const r = await fetch('/api/scans?limit=90')
     const j = await r.json()
     setItems(j)
   }
 
-  useEffect(() => { load() }, [])
+  useEffect(() => { loadList() }, [])
+
+  useEffect(() => {
+    if (orderedItems.length > 0 && !selectedId) {
+      setSelectedId(orderedItems[0].id)
+    }
+  }, [orderedItems, selectedId])
+
+  useEffect(() => {
+    if (!selectedId || details[selectedId]) return
+    let cancelled = false
+    setDetailError(null)
+    setLoadingId(selectedId)
+
+    async function loadDetail(id: string) {
+      try {
+        const r = await fetch(`/api/scans/${id}`)
+        if (!r.ok) throw new Error(`Failed to load scan ${id}`)
+        const data = await r.json()
+        if (!cancelled) {
+          setDetails(prev => ({ ...prev, [id]: data }))
+        }
+      } catch (err: any) {
+        if (!cancelled) {
+          setDetailError(err.message || 'Unable to load run details.')
+        }
+      } finally {
+        if (!cancelled) {
+          setLoadingId(current => (current === id ? null : current))
+        }
+      }
+    }
+
+    loadDetail(selectedId)
+
+    return () => { cancelled = true }
+  }, [selectedId, details])
+
+  function selectRun(id: string) {
+    setDetailError(null)
+    setSelectedId(id)
+  }
+
+  const selectedDetail = selectedId ? details[selectedId] : null
 
   return (
-    <div className="min-h-screen">
+    <div className="min-h-screen bg-slate-50">
       <Header onRescan={() => {}} />
-      <main className="max-w-4xl mx-auto p-4">
-        <h2 className="text-lg font-semibold mb-3">Daily Log</h2>
-        <table className="min-w-full border text-sm">
-          <thead className="bg-gray-50">
-            <tr>
-              <th className="text-left p-2 border-r">Date (start)</th>
-              <th className="text-left p-2 border-r">Completed</th>
-              <th className="text-left p-2 border-r">Articles</th>
-              <th className="text-left p-2">Kind</th>
-            </tr>
-          </thead>
-          <tbody>
-            {items.map(it => (
-              <tr key={it.id} className="odd:bg-white even:bg-gray-50">
-                <td className="p-2 border-r"><a className="underline" href={`/api/scans/${it.id}`} target="_blank" rel="noreferrer">{new Date(it.run_started_at).toLocaleString()}</a></td>
-                <td className="p-2 border-r">{it.run_completed_at ? new Date(it.run_completed_at).toLocaleString() : '—'}</td>
-                <td className="p-2 border-r">{it.total_articles}</td>
-                <td className="p-2">{it.schedule_kind}</td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
+      <main className="mx-auto max-w-7xl px-4 pb-24">
+        <section className="mt-6" aria-label="Scan history">
+          <div className="flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
+            <div>
+              <h1 className="text-2xl font-semibold text-slate-900">Daily log</h1>
+              <p className="mt-1 text-sm text-slate-600">
+                Select a run to review its summaries and captured articles without leaving the dashboard.
+              </p>
+            </div>
+            <p className="text-xs uppercase tracking-wide text-slate-500">Showing {orderedItems.length} runs</p>
+          </div>
+
+          <div className="mt-4 overflow-hidden rounded-3xl border border-slate-200 bg-white shadow-sm">
+            <table className="hidden min-w-full text-sm text-slate-700 md:table">
+              <thead className="bg-slate-50 text-xs font-semibold uppercase tracking-wide text-slate-500">
+                <tr>
+                  <th className="px-4 py-3 text-left">Started</th>
+                  <th className="px-4 py-3 text-left">Completed</th>
+                  <th className="px-4 py-3 text-left">Articles</th>
+                  <th className="px-4 py-3 text-left">Kind</th>
+                </tr>
+              </thead>
+              <tbody>
+                {orderedItems.map(it => {
+                  const isSelected = it.id === selectedId
+                  return (
+                    <tr
+                      key={it.id}
+                      role="button"
+                      tabIndex={0}
+                      onClick={() => selectRun(it.id)}
+                      onKeyDown={evt => {
+                        if (evt.key === 'Enter' || evt.key === ' ') {
+                          evt.preventDefault()
+                          selectRun(it.id)
+                        }
+                      }}
+                      className={`transition-colors ${isSelected ? 'bg-slate-100' : 'odd:bg-white even:bg-slate-50 hover:bg-slate-100/70 focus-visible:bg-slate-100'}`}
+                    >
+                      <td className="px-4 py-3 font-medium text-slate-900">{new Date(it.run_started_at).toLocaleString()}</td>
+                      <td className="px-4 py-3">{it.run_completed_at ? new Date(it.run_completed_at).toLocaleString() : '—'}</td>
+                      <td className="px-4 py-3">{it.total_articles ?? '—'}</td>
+                      <td className="px-4 py-3 capitalize">{it.schedule_kind.replace(/_/g, ' ')}</td>
+                    </tr>
+                  )
+                })}
+              </tbody>
+            </table>
+
+            <div className="divide-y divide-slate-200 md:hidden" role="list">
+              {orderedItems.map(it => {
+                const isSelected = it.id === selectedId
+                return (
+                  <button
+                    type="button"
+                    key={it.id}
+                    onClick={() => selectRun(it.id)}
+                    aria-pressed={isSelected}
+                    className={`w-full text-left transition ${isSelected ? 'bg-slate-100' : 'bg-white'} focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-slate-400`}
+                    role="listitem"
+                  >
+                    <div className="px-4 py-3">
+                      <p className="text-sm font-semibold text-slate-900">{new Date(it.run_started_at).toLocaleString()}</p>
+                      <dl className="mt-2 grid grid-cols-2 gap-2 text-xs text-slate-600">
+                        <div>
+                          <dt className="uppercase tracking-wide text-slate-500">Completed</dt>
+                          <dd className="mt-0.5 text-slate-700">{it.run_completed_at ? new Date(it.run_completed_at).toLocaleString() : '—'}</dd>
+                        </div>
+                        <div>
+                          <dt className="uppercase tracking-wide text-slate-500">Articles</dt>
+                          <dd className="mt-0.5 text-slate-700">{it.total_articles ?? '—'}</dd>
+                        </div>
+                        <div className="col-span-2">
+                          <dt className="uppercase tracking-wide text-slate-500">Kind</dt>
+                          <dd className="mt-0.5 text-slate-700 capitalize">{it.schedule_kind.replace(/_/g, ' ')}</dd>
+                        </div>
+                      </dl>
+                    </div>
+                  </button>
+                )
+              })}
+            </div>
+          </div>
+        </section>
+
+        <section className="mt-8" aria-live="polite" aria-busy={loadingId === selectedId}>
+          {!selectedId && (
+            <div className="rounded-3xl border border-dashed border-slate-300 bg-white/60 px-6 py-10 text-center text-sm text-slate-600">
+              Select a run from the log to view its details.
+            </div>
+          )}
+
+          {selectedId && (
+            <div className="mt-4 space-y-4">
+              {loadingId === selectedId && !selectedDetail && (
+                <div className="rounded-3xl border border-slate-200 bg-white px-6 py-6 text-sm text-slate-600 shadow-sm">
+                  Loading run details…
+                </div>
+              )}
+              {detailError && loadingId !== selectedId && !selectedDetail && (
+                <div className="rounded-3xl border border-red-200 bg-red-50 px-6 py-6 text-sm text-red-700 shadow-sm">
+                  {detailError}
+                </div>
+              )}
+              {selectedDetail && <RunDetailPanel data={selectedDetail} />}
+            </div>
+          )}
+        </section>
       </main>
     </div>
   )

--- a/web/src/pages/Today.tsx
+++ b/web/src/pages/Today.tsx
@@ -3,23 +3,12 @@ import Header from '../components/Header'
 import CategoryColumn, { type CategoryItem } from '../components/CategoryColumn'
 import SummaryCard from '../components/SummaryCard'
 import StatusBar from '../components/StatusBar'
+import { CATEGORY_LABELS, CATEGORY_ORDER } from '../components/categoryLabels'
 
 type ScanPayload = {
   meta: { id: string, run_started_at: string }
   categories: Record<string, CategoryItem[]>
   summaries: Record<string, any>
-}
-
-const CAT_LABELS: Record<string,string> = {
-  international: "International",
-  domestic_politics: "Domestic Politics",
-  business: "Business/Economy",
-  society: "Society",
-  technology: "Technology",
-  military: "Military/Defense",
-  science: "Science/Research",
-  opinion: "Opinion/Commentary",
-  uncategorized: "Uncategorized"
 }
 
 export default function Today() {
@@ -48,7 +37,7 @@ export default function Today() {
     else { alert('Failed: ' + (await r.text())) }
   }
 
-  const order = useMemo(() => Object.keys(CAT_LABELS), [])
+  const order = useMemo(() => CATEGORY_ORDER, [])
   const briefingMeta = useMemo(() => {
     if (!data) return null
     const totalArticles = order.reduce((sum, key) => sum + (data.categories[key]?.length || 0), 0)
@@ -96,7 +85,7 @@ export default function Today() {
               </div>
               <div className="grid gap-6 md:grid-cols-2 xl:grid-cols-3">
                 {order.map(c => (
-                  <CategoryColumn key={c} title={CAT_LABELS[c]} items={data.categories[c] || []} />
+                  <CategoryColumn key={c} title={CATEGORY_LABELS[c]} items={data.categories[c] || []} />
                 ))}
               </div>
             </section>
@@ -107,7 +96,7 @@ export default function Today() {
               </div>
               <div className="grid gap-6 md:grid-cols-2">
                 {order.map(c => (
-                  <SummaryCard key={c} title={CAT_LABELS[c]} data={data.summaries[c]} />
+                  <SummaryCard key={c} title={CATEGORY_LABELS[c]} data={data.summaries[c]} />
                 ))}
               </div>
             </section>


### PR DESCRIPTION
## Summary
- add shared category label constants for reuse across pages
- enhance the log page to fetch run details inline with responsive metadata, summaries, and article coverage views
- create reusable expandable and run detail components to organize scan content

## Testing
- npm --prefix web run build

------
https://chatgpt.com/codex/tasks/task_e_68dfd3cb91dc8331ac467f5192b05d80